### PR TITLE
feature: add internal group to import/order rule

### DIFF
--- a/eslint-config-base/index.js
+++ b/eslint-config-base/index.js
@@ -145,7 +145,7 @@ module.exports = {
     'import/first': 2,
     'import/no-duplicates': 2,
     'import/order': [2, {
-      groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
+      groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
       pathGroups: [
         {
           pattern: '*.+(png|svg)',


### PR DESCRIPTION
Without `internal` group these imports will fail:

```js
import urls from 'config/urls';
import jamfIcon from './images/jamf.svg';
```

to fix this need to add `internal` group to the rule.