### PR TITLE
Tune requirements for dependencies

### DIFF
--- a/eslint-config-base/package.json
+++ b/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macpaw/eslint-config-base",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "scripts": {
     "version:patch": "yarn version --patch --no-git-tag-version",

--- a/eslint-config-base/package.json
+++ b/eslint-config-base/package.json
@@ -8,10 +8,10 @@
     "version:major": "yarn version --major --no-git-tag-version"
   },
   "dependencies": {
-    "eslint-plugin-import": "2.23.4"
+    "eslint-plugin-import": "^2.23.4"
   },
   "devDependencies": {
-    "eslint": "7.31.0"
+    "eslint": "^7.31.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"

--- a/eslint-config-base/package.json
+++ b/eslint-config-base/package.json
@@ -14,7 +14,7 @@
     "eslint": "7.31.0"
   },
   "peerDependencies": {
-    "eslint": "*"
+    "eslint": "^6.0.0 || ^7.0.0"
   },
   "files": [
     "index.js"

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -16,7 +16,7 @@
     "eslint": "7.31.0"
   },
   "peerDependencies": {
-    "eslint": "*"
+    "eslint": "^6.0.0 || ^7.0.0"
   },
   "files": [
     "index.js"

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -8,12 +8,12 @@
     "version:major": "yarn version --major --no-git-tag-version"
   },
   "dependencies": {
-    "eslint-plugin-jsx-a11y": "6.4.1",
-    "eslint-plugin-react": "7.24.0",
-    "eslint-plugin-react-hooks": "4.2.0"
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-react": "^7.24.0",
+    "eslint-plugin-react-hooks": "^4.2.0"
   },
   "devDependencies": {
-    "eslint": "7.31.0"
+    "eslint": "^7.31.0"
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0"

--- a/eslint-config-react/package.json
+++ b/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macpaw/eslint-config-react",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "scripts": {
     "version:patch": "yarn version --patch --no-git-tag-version",

--- a/eslint-config-typescript/package.json
+++ b/eslint-config-typescript/package.json
@@ -8,11 +8,11 @@
     "version:major": "yarn version --major --no-git-tag-version"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "4.28.5",
-    "@typescript-eslint/parser": "4.28.5"
+    "@typescript-eslint/eslint-plugin": "^4.28.5",
+    "@typescript-eslint/parser": "^4.28.5"
   },
   "devDependencies": {
-    "eslint": "7.31.0",
+    "eslint": "^7.31.0",
     "typescript": "^4.0.0"
   },
   "peerDependencies": {

--- a/eslint-config-typescript/package.json
+++ b/eslint-config-typescript/package.json
@@ -16,8 +16,8 @@
     "typescript": "^4.0.0"
   },
   "peerDependencies": {
-    "eslint": "*",
-    "typescript": "*"
+    "eslint": "^6.0.0 || ^7.0.0",
+    "typescript": "^4.0.0"
   },
   "files": [
     "index.js"

--- a/eslint-config-typescript/package.json
+++ b/eslint-config-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@macpaw/eslint-config-typescript",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "scripts": {
     "version:patch": "yarn version --patch --no-git-tag-version",

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,7 +93,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
-"@typescript-eslint/eslint-plugin@4.28.5":
+"@typescript-eslint/eslint-plugin@^4.28.5":
   version "4.28.5"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.5.tgz#8197f1473e7da8218c6a37ff308d695707835684"
   integrity sha512-m31cPEnbuCqXtEZQJOXAHsHvtoDi9OVaeL5wZnO2KZTnkvELk+u6J6jHg+NzvWQxk+87Zjbc4lJS4NHmgImz6Q==
@@ -118,7 +118,7 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@4.28.5":
+"@typescript-eslint/parser@^4.28.5":
   version "4.28.5"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.5.tgz#9c971668f86d1b5c552266c47788a87488a47d1c"
   integrity sha512-NPCOGhTnkXGMqTznqgVbA5LqVsnw+i3+XA1UKLnAb+MG1Y1rP4ZSK9GX0kJBmAZTMIktf+dTwXToT6kFwyimbw==
@@ -519,7 +519,7 @@ eslint-module-utils@^2.6.1:
     debug "^3.2.7"
     pkg-dir "^2.0.0"
 
-eslint-plugin-import@2.23.4:
+eslint-plugin-import@^2.23.4:
   version "2.23.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz#8dceb1ed6b73e46e50ec9a5bb2411b645e7d3d97"
   integrity sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==
@@ -540,7 +540,7 @@ eslint-plugin-import@2.23.4:
     resolve "^1.20.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jsx-a11y@6.4.1:
+eslint-plugin-jsx-a11y@^6.4.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz#a2d84caa49756942f42f1ffab9002436391718fd"
   integrity sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
@@ -557,12 +557,12 @@ eslint-plugin-jsx-a11y@6.4.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
-eslint-plugin-react-hooks@4.2.0:
+eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
   integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
 
-eslint-plugin-react@7.24.0:
+eslint-plugin-react@^7.24.0:
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.24.0.tgz#eadedfa351a6f36b490aa17f4fa9b14e842b9eb4"
   integrity sha512-KJJIx2SYx7PBx3ONe/mEeMz4YE0Lcr7feJTCMyyKb/341NcjuAgim3Acgan89GfPv7nxXK2+0slu0CWXYM4x+Q==
@@ -612,7 +612,7 @@ eslint-visitor-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
 
-eslint@7.31.0:
+eslint@^7.31.0:
   version "7.31.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.31.0.tgz#f972b539424bf2604907a970860732c5d99d3aca"
   integrity sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==


### PR DESCRIPTION
## Features

- get back min version requirement for Eslint end TypeScript (Eslint v5 is not supported because it doesn't support ES2020 syntax)
- chore: set less strict requirements for dependencies