### PR TITLE
Require trailing commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Extend necessary configs inside `.eslintrc.json`:
 2. [Create new release](https://github.com/MacPaw/eslint-config/releases/new)
 
 ## Testing in related projects
-There is a way to test new version of eslint-config without publishing it to github packages:
+There is a way to test new version of eslint-config without publishing it to npm:
 
 1. Execute `npm link` inside a necessary config project root.
 2. Execute `npm link @macpaw/eslint-config-${name}` inside related project's root.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ Extend necessary configs inside `.eslintrc.json`:
 
 1. Run one of `yarn patch`, `yarn minor`, `yarn major` scripts to bump package.json version for each package
 2. [Create new release](https://github.com/MacPaw/eslint-config/releases/new)
+
+## Testing in related projects
+There is a way to test new version of eslint-config without publishing it to github packages:
+
+1. Execute `npm link` inside a necessary config project root.
+2. Execute `npm link @macpaw/eslint-config-${name}` inside related project's root.
+3. Rebuild related project if needed.

--- a/eslint-config-base/index.js
+++ b/eslint-config-base/index.js
@@ -49,6 +49,13 @@ module.exports = {
     'prefer-promise-reject-errors': [2, { allowEmptyReject: true }],
     'yoda': 2,
     'require-atomic-updates': 2,
+    'comma-dangle': [2, {
+      'arrays': 'always-multiline',
+      'objects': 'always-multiline',
+      'imports': 'always-multiline',
+      'exports': 'always-multiline',
+      'functions': 'only-multiline',
+    }],
 
     // ES
     'no-var': 2,


### PR DESCRIPTION
There is a rule in the old config, so I suggest adding it back. 
It does not require big changes in existing projects but allows to make of new ones with this rule.

From eslint [docs](https://eslint.org/docs/rules/comma-dangle): "Trailing commas simplify adding and removing items to objects and arrays, since only the lines you are modifying must be touched"

Also, it fixed #4 